### PR TITLE
Replace BlocksRenderer with BlocksRendererClient for better image handling

### DIFF
--- a/components/common/BlockRendererClient.tsx
+++ b/components/common/BlockRendererClient.tsx
@@ -6,8 +6,6 @@ import {
   type BlocksContent,
 } from "@strapi/blocks-react-renderer";
 
-import { getImageUrl } from "@/utils/image";
-
 const BlocksRendererClient = ({
   content,
 }: {

--- a/components/common/BlockRendererClient.tsx
+++ b/components/common/BlockRendererClient.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import Image from "next/image";
+import {
+  BlocksRenderer,
+  type BlocksContent,
+} from "@strapi/blocks-react-renderer";
+
+import { getImageUrl } from "@/utils/image";
+
+const BlocksRendererClient = ({
+  content,
+}: {
+  readonly content: BlocksContent;
+}) => {
+  if (!content) return null;
+  return (
+    <BlocksRenderer
+      content={content}
+      blocks={{
+        image: ({ image }) => {
+          return (
+            <Image
+              src={image.url}
+              width={image.width}
+              height={image.height}
+              alt={image.alternativeText ?? "Blog detail image"}
+            />
+          );
+        },
+      }}
+    />
+  );
+};
+
+export default BlocksRendererClient;

--- a/components/media/article-detail/ArticleDetail.tsx
+++ b/components/media/article-detail/ArticleDetail.tsx
@@ -1,5 +1,4 @@
 import { BlocksContent } from "@strapi/blocks-react-renderer";
-import { BlocksRenderer } from "@strapi/blocks-react-renderer";
 
 import { ApiPath, apiRequest } from "@/utils/apiClient";
 import { getArticlesCollectionQuery } from "@/utils/articlesCollectionQuery";
@@ -11,6 +10,7 @@ import ArticleCard from "@/components/media/ArticleCard";
 import ContainerSection from "@/components/layout/container";
 import ContainerBlog from "@/components/layout/ContainerBlog";
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
+import BlocksRendererClient from "@/components/common/BlockRendererClient";
 
 const getApiPathByType = (type: string): ApiPath => {
   return type === "news" ? ApiPath.NEWS : ApiPath.BLOGS;
@@ -52,11 +52,10 @@ const ArticleDetail = ({
   content: BlocksContent;
   type: string;
 }) => {
-  console.log("ini type", type);
   return (
     <section>
       <ContainerBlog>
-        <BlocksRenderer content={content} />
+        <BlocksRendererClient content={content} />
       </ContainerBlog>
       <ContainerSection>
         <OtherArticle type={type} />


### PR DESCRIPTION
Introduce BlocksRendererClient to enhance image rendering in articles and remove unused imports from the BlockRendererClient component.